### PR TITLE
Creating method/function/domain refs

### DIFF
--- a/crates/slang/src/lib.rs
+++ b/crates/slang/src/lib.rs
@@ -9,7 +9,7 @@ pub mod tc;
 
 use std::sync::{Arc, RwLock};
 
-use ast::{Ident, Ref};
+use ast::{DomainRef, FunctionRef, Ident, MethodRef, Ref};
 use indexmap::IndexMap;
 pub use parse::ParseResult;
 pub use span::{Position, Span};
@@ -33,6 +33,16 @@ impl SourceFile {
     }
     pub fn globals(&self) -> Vec<Arc<ast::Global>> {
         self.items.globals()
+    }
+
+    pub fn get_method_ref(&self, ident: Ident) -> MethodRef {
+        MethodRef(self.items.new_ref(ident))
+    }
+    pub fn get_function_ref(&self, ident: Ident) -> FunctionRef {
+        FunctionRef(self.items.new_ref(ident))
+    }
+    pub fn get_domain_ref(&self, ident: Ident) -> DomainRef {
+        DomainRef(self.items.new_ref(ident))
     }
 
     pub fn contains_error(&self) -> bool {


### PR DESCRIPTION
To create method / function calls you need a reference to the called method / function. I don't think there is currently a way to create such a reference. I added some methods to do that. Feel free to let me know if there's a better way or a reason not to do it like this :)